### PR TITLE
Clang 16 fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -333,7 +333,7 @@ else
 	echo $ECHO_N "checking compile sign warning flags ... $ECHO_C"
 	cfwarn="-Wno-pointer-sign -Wno-sign-conversion"
     # want "-Wno-unused-result", but unrecognized
-	echo "int main() { return(1); }" >$tmpc
+	echo "int main(void) { return(1); }" >$tmpc
 	$CC -o $tmpo -c $cfwarn $tmpc  >/dev/null 2>&1
 	if test $? -ne 0 ; then
 	   cfwarn=
@@ -344,7 +344,7 @@ else
         rm -f $tmpc $tmpo >/dev/null 2>&1
 	echo $ECHO_N "checking compile gnu warning flags ... $ECHO_C"
         cfgnu="-Wgnu-designator"
-	echo "int main() { return(1); }" >$tmpc
+	echo "int main(void) { return(1); }" >$tmpc
 	$CC -o $tmpo -c $cfgnu $tmpc  >/dev/null 2>&1
 	if test $? -ne 0 ; then
 	   cfgnu=
@@ -355,7 +355,7 @@ else
 	rm -f $tmpc $tmpo >/dev/null 2>&1
 	echo $ECHO_N "checking strict aliasing warning flags ... $ECHO_C"
 	cfalias="-fno-strict-aliasing"
-	echo "int main() { return(1); }" >$tmpc
+	echo "int main(void) { return(1); }" >$tmpc
 	$CC -o $tmpo -c $cfalias $tmpc  >/dev/null 2>&1
 	if test $? -ne 0 ; then
 	   cfalias=
@@ -366,7 +366,8 @@ else
 	rm -f $tmpc $tmpo >/dev/null 2>&1
 	echo $ECHO_N "checking compile fortify flags ... $ECHO_C"
 	cfhard="-fstack-protector --param=ssp-buffer-size=4 -D_FORTIFY_SOURCE=2"
-	echo "int main() { alloca(100); return(1); }" >$tmpc
+	echo "#include <alloca.h>
+	int main(void) { alloca(100); return(1); }" >$tmpc
 	$CC -o $tmpo $cfhard $tmpc  >/dev/null 2>&1
 	if test $? -ne 0 ; then
 	   cfhard=

--- a/lib/lanplus/lanplus.h
+++ b/lib/lanplus/lanplus.h
@@ -132,4 +132,6 @@ int  ipmi_lanplus_open(struct ipmi_intf * intf);
 void ipmi_lanplus_close(struct ipmi_intf * intf);
 int ipmiv2_lan_ping(struct ipmi_intf * intf);
 
+void os_assert(char *msg);
+
 #endif /*IPMI_LAN_H*/


### PR DESCRIPTION
Clang 16 makes -Wimplicit-function-declaration an error by default.

Unfortunately, this can lead to misconfiguration or miscompilation of software as configure
tests may then return the wrong result.

We also fix -Wstrict-prototypes while here as it's easy to do and it prepares
us for C23.

For more information, see LWN.net [0] or LLVM's Discourse [1], the Gentoo wiki [2],
or the (new) c-std-porting mailing list [3].

[0] https://lwn.net/Articles/913505/
[1] https://discourse.llvm.org/t/configure-script-breakage-with-the-new-werror-implicit-function-declaration/65213
[2] https://wiki.gentoo.org/wiki/Modern_C_porting
[3] hosted at lists.linux.dev.

Bug: https://bugs.gentoo.org/879765
Signed-off-by: Sam James <sam@gentoo.org>