### PR TITLE
fix #14

### DIFF
--- a/util/ilan.c
+++ b/util/ilan.c
@@ -1001,7 +1001,7 @@ GetUserInfo (uchar unum, uchar chan, uchar * enab, uchar * priv, char *uname,
       max_users = responseData[0] & 0x3f;
       enabled_users = responseData[1] & 0x3f;
     }
-    upriv = responseData[3];
+    upriv = responseData[3] & 0x0F;
     if ((responseData[1] & 0x80) != 0) *enab = 0;
     else *enab = 1;
     inputData[0] = unum;	/* usually = 1 for BMC LAN */


### PR DESCRIPTION
This is the pull request to fix issue #14.

It applies the fix provided by @vien20010, which was later approved by @arcress0.
The problem is a bug in the GetUserInfo-function, resulting in users of ipmiutil not being able to change the password of an ipmi-user